### PR TITLE
fix test interface

### DIFF
--- a/vaultpkitest/vaultpkitest.go
+++ b/vaultpkitest/vaultpkitest.go
@@ -38,3 +38,7 @@ func (p *VaultPKITest) GetBackend(ID string) (*vaultapi.MountOutput, error) {
 func (p *VaultPKITest) GetCACertificate(ID string) (string, error) {
 	return "", nil
 }
+
+func (p *VaultPKITest) ListBackends() ([]*vaultapi.MountOutput, error) {
+	return nil, nil
+}

--- a/vaultpkitest/vaultpkitest_test.go
+++ b/vaultpkitest/vaultpkitest_test.go
@@ -1,0 +1,14 @@
+package vaultpkitest
+
+import (
+	"testing"
+
+	"github.com/giantswarm/vaultpki"
+)
+
+func Test_VaultPKITest_New_Interface(t *testing.T) {
+	// Create an anonymus function that takes the interface as argument and
+	// provide the test implementation in order to verify it implements the actual
+	// interface.
+	func(v vaultpki.Interface) {}(New())
+}


### PR DESCRIPTION
When importing in `cert-operator` I noticed the test package does not implement the extension we recently added. Fixing this here and providing a unit test so it does not happen again. 🚀 