### PR TITLE
expose PKI backend path when listing

### DIFF
--- a/current.go
+++ b/current.go
@@ -75,20 +75,20 @@ func (p *VaultPKI) GetCACertificate(ID string) (string, error) {
 	return crt, nil
 }
 
-func (p *VaultPKI) ListBackends() ([]*vaultapi.MountOutput, error) {
+func (p *VaultPKI) ListBackends() (map[string]*vaultapi.MountOutput, error) {
 	mounts, err := p.vaultClient.Sys().ListMounts()
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	var list []*vaultapi.MountOutput
+	var backends map[string]*vaultapi.MountOutput
 	for k, v := range mounts {
 		if !key.IsMountPath(k) {
 			continue
 		}
 
-		list = append(list, v)
+		backends[k] = v
 	}
 
-	return list, nil
+	return backends, nil
 }

--- a/current.go
+++ b/current.go
@@ -81,7 +81,7 @@ func (p *VaultPKI) ListBackends() (map[string]*vaultapi.MountOutput, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	var backends map[string]*vaultapi.MountOutput
+	backends := map[string]*vaultapi.MountOutput{}
 	for k, v := range mounts {
 		if !key.IsMountPath(k) {
 			continue

--- a/key/key.go
+++ b/key/key.go
@@ -10,6 +10,16 @@ func CommonName(ID string, commonNameFormat string) string {
 	return fmt.Sprintf(commonNameFormat, ID)
 }
 
+// ClusterIDFromMountPath aligns with the implementation details of IsMountPath
+// and expects a valid mount path to work properly. A valid mount path must look
+// something like the following, where "z4574" is the cluster ID.
+//
+//     pki-z4574/
+//
+func ClusterIDFromMountPath(path string) string {
+	return path[4:9]
+}
+
 func ListMountsPath(ID string) string {
 	return fmt.Sprintf("pki-%s/", ID)
 }

--- a/spec.go
+++ b/spec.go
@@ -12,5 +12,5 @@ type Interface interface {
 	DeleteBackend(ID string) error
 	GetBackend(ID string) (*vaultapi.MountOutput, error)
 	GetCACertificate(ID string) (string, error)
-	ListBackends() ([]*vaultapi.MountOutput, error)
+	ListBackends() (map[string]*vaultapi.MountOutput, error)
 }

--- a/vaultpkitest/vaultpkitest.go
+++ b/vaultpkitest/vaultpkitest.go
@@ -39,6 +39,6 @@ func (p *VaultPKITest) GetCACertificate(ID string) (string, error) {
 	return "", nil
 }
 
-func (p *VaultPKITest) ListBackends() ([]*vaultapi.MountOutput, error) {
+func (p *VaultPKITest) ListBackends() (map[string]*vaultapi.MountOutput, error) {
 	return nil, nil
 }


### PR DESCRIPTION
I noticed the mount output does not contain the actual information we need for listing backends, which is the mount path itself. This contains the cluster ID. So here we simply extend the interface and expose the mount path additionally so that we get the cluster ID. 